### PR TITLE
feat: Add peer-directory workspace strategy for migrations

### DIFF
--- a/SKILL-UPDATE-PLAN.md
+++ b/SKILL-UPDATE-PLAN.md
@@ -443,6 +443,37 @@ Created in `skills/universal-code-graph/queries/`:
 - javascript-definitions.scm, javascript-imports.scm, javascript-calls.scm
 - java-definitions.scm, java-imports.scm
 
+## Round 6: Workspace Strategy (2026-02-17)
+
+Previously, the skill suite assumed in-place modification of the source tree. This was risky — one bad conversion could corrupt the production codebase, and rollback depended entirely on git revert. Round 6 adds a peer-directory workspace strategy.
+
+### Changes Made
+
+| # | What | Status | Notes |
+|---|------|--------|-------|
+| R6-1 | Added "Step 0: Create the Workspace" to project-initializer SKILL.md | COMPLETE | Peer directory strategy, git branch setup, rationale |
+| R6-2 | Updated init_migration_project.py | COMPLETE | Added `--workspace`, `--in-place`, `--workflow` flags; auto-creates `<project>-py3/` copy; creates git branch; records source_root + workspace in migration-state.json |
+| R6-3 | Updated Inputs/Outputs in project-initializer SKILL.md | COMPLETE | New inputs table, workspace output row, migration-state includes paths |
+| R6-4 | Added "Workspace Assumption" section to automated-converter SKILL.md | COMPLETE | Clarifies that codebase_path should be the workspace, not original source |
+| R6-5 | Updated HANDOFF-PROMPT-GUIDE.md context block | COMPLETE | Handoff prompts now include both workspace and original source paths |
+
+### Key Design Decision
+
+```
+parent-dir/
+├── my-project/              ← original source (READ-ONLY during migration)
+├── my-project-py3/          ← working copy (all edits happen here)
+│   ├── <full source copy>
+│   └── migration-analysis/  ← scaffolding, reports, state
+```
+
+**Why peer directory, not in-place?**
+- Original source always available for diff comparison
+- No risk of corrupting production codebase
+- Git history stays clean (migration is one branch)
+- Easy rollback: delete workspace and start over
+- Multiple migration attempts can coexist
+
 ## Next Steps (Remaining Work)
 
 ### P2: Additional Tree-sitter Queries

--- a/skills/py2to3-automated-converter/SKILL.md
+++ b/skills/py2to3-automated-converter/SKILL.md
@@ -33,17 +33,23 @@ except-as, old-style string types, relative imports, etc.
 - When you need to track which files succeeded and which failed
 - When you need to integrate with CI/CD to validate the converted code
 
+## Workspace Assumption
+
+This skill assumes you are running against a **workspace copy**, not the original source repo. The project initializer creates a peer directory (`<project>-py3/`) that contains a full copy of the source tree. All conversion edits happen in-place within that workspace — the original source remains untouched as a diff baseline.
+
+If `migration-state.json` exists, it contains `source_root` and `workspace` paths. Use the workspace path as `codebase_path`.
+
 ## Inputs
 
 The user (or orchestration) provides:
 
 | Input | Type | Purpose |
 |-------|------|---------|
-| **codebase_path** | path | Root directory of the Python 2 codebase |
+| **codebase_path** | path | Root directory of the workspace (the `-py3` copy, not the original) |
 | **modules** | list of paths | Individual module files to convert (or `--unit <name>` to use conversion plan) |
 | **target_version** | string | Target Python 3 version: `3.9`, `3.11`, `3.12`, or `3.13` |
 | **--unit** | string | Conversion unit name from conversion-plan.json (resolves to module list automatically) |
-| **--output** | path | Output directory for converted files (default: same as source) |
+| **--output** | path | Output directory for converted files (default: modify in workspace) |
 | **--dry-run** | flag | Show what would change without modifying files |
 | **--state-file** | path | Path to migration-state.json (for tracking progress) |
 | **--conversion-plan** | path | Path to conversion-plan.json from Skill 2.1 (for unit resolution) |

--- a/skills/py2to3-project-initializer/references/HANDOFF-PROMPT-GUIDE.md
+++ b/skills/py2to3-project-initializer/references/HANDOFF-PROMPT-GUIDE.md
@@ -7,12 +7,13 @@ A handoff prompt is a self-contained document that lets someone (or an agent) co
 Every handoff prompt should contain these sections:
 
 ### 1. Context Block
-State what project this is, where it lives, what the target Python version is, and which phases are complete with their gate status.
+State what project this is, where the **workspace** lives (the `-py3` copy, not the original source), what the target Python version is, and which phases are complete with their gate status.
 
 Example:
 ```
-This is Phase 3 (Semantic Fixes) of a Python 2→3 migration for the "Legacy Industrial Data Platform"
-at /path/to/project.
+This is Phase 3 (Semantic Fixes) of a Python 2→3 migration for the "Legacy Industrial Data Platform".
+Workspace: /path/to/project-py3  (working copy — all edits here)
+Original source: /path/to/project  (read-only reference for diffs)
 
 Phases completed:
 - Phase 0 (Discovery): PASS — codebase analyzed, 699 Py2-isms inventoried


### PR DESCRIPTION
## Summary

- Migrations now operate on a `<project>-py3/` peer copy of the source tree instead of modifying the original codebase in-place
- `init_migration_project.py` gains `--workspace`, `--in-place`, and `--workflow` flags for flexible workspace setup
- `migration-state.json` tracks both `source_root` and `workspace` paths so downstream skills know which directory to target

## Details

The original source stays read-only as a diff baseline and rollback target. The automated-converter SKILL.md now documents this workspace assumption, and the handoff prompt guide includes both paths in context blocks. Round 6 rationale and design decisions captured in SKILL-UPDATE-PLAN.md.

## Test plan

- [ ] Run `init_migration_project.py` on a sample Python 2 project — verify it creates the `-py3` peer directory
- [ ] Verify `migration-state.json` contains correct `source_root` and `workspace` paths
- [ ] Run with `--in-place` flag — verify it warns and works directly on source
- [ ] Run with `--workspace /custom/path` — verify custom location is used
- [ ] Verify existing workspace is detected and not overwritten on re-run