### PR TITLE
extract-contracts: Add --skip-existing for resumable extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,128 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+A toolkit for code translation/migration organized around the **vertical plane model**: a language-neutral specification sits between extraction (old code) and generation (new code). The spec is always produced, even for same-language upgrades (e.g. Java 8 to 17), to sever the source language's gravitational pull on the target.
+
+```
+Old Code  -->  [ Extraction ]  -->  SPECIFICATION  -->  [ Generation ]  -->  New Code
+                 (left side)        (the plane)          (right side)
+```
+
+The spec (`spec.json`) is the central artifact. Everything feeds into it or reads from it.
+
+## Architecture
+
+### Skills (`skills/`)
+
+Each skill is a self-contained directory with a `SKILL.md` (agent instructions) and implementation scripts. Skills are designed to be invoked by Claude Code agents, not run as standalone CLI tools (though the scripts can be run directly).
+
+| Skill | Milestone | What it does |
+|---|---|---|
+| `discover` | M1 | Orchestrates treeloom/greploom/sanicode/veripak to produce a skeleton `spec.json` with structure and security data, contracts left empty |
+| `extract-contracts` | M2 | Queries greploom for source context, prompts an LLM to infer behavioral contracts, writes them into the spec |
+| `library-replacement` | M2 | Identifies imports needing replacement via treeloom, applies YAML mapping files |
+
+### Spec schema (`spec-schema/`)
+
+- `spec.schema.json` — JSON Schema (Draft 2020-12) defining the spec format
+- `examples/` — Hand-crafted gold-standard specs for dateutil-parser and jsoup-safety (used for comparison/evaluation)
+- `render.py` — Validates spec against schema and renders to Markdown via Jinja2
+- `templates/spec-review.md.j2` — Review template
+
+### Spec structure
+
+Top-level sections: `meta`, `cpg_ref`, `elements`, `security_findings`, `ecosystem_dependencies`, `usage_paths`.
+
+Elements are keyed by human-readable IDs using prefixes: `mod:`, `cls:`, `fn:`. Each element carries a `contract` (purpose, preconditions, postconditions, invariants, side_effects, error_conditions, trust_boundary) and `metadata` (confidence, source, status).
+
+### External tool dependencies
+
+The kit delegates to purpose-built tools rather than reimplementing analysis:
+
+| Tool | Purpose | Install |
+|---|---|---|
+| **treeloom** (0.9.0+) | Code property graph builder (AST + call graph) | `pip install treeloom` |
+| **greploom** (0.5.0+) | Semantic search over CPGs | `pip install greploom` |
+| **veripak** | Dependency audit (CVEs, licenses) | `pip install veripak` |
+| **sanicode** | SAST with compliance mapping | `pip install sanicode` |
+
+### Reference codebases (external)
+
+These live outside this repo at `~/Developer/`:
+
+- `dateutil-example/` — Python. 17 source files, 372 elements. Primary test subject for extraction.
+- `jsoup-example/` — Java. 184 source files, 4547 elements. Secondary test subject.
+
+Each contains: `cpg.json`, `greploom.db`, `spec.json`, sanicode/veripak outputs.
+
+## Running the scripts
+
+All scripts are standalone Python, no package install required. The venv at `.venv/` has dependencies (requests, jsonschema, jinja2).
+
+```bash
+# Rebuild a skeleton spec from CPG + tool outputs
+python3 skills/discover/assemble.py \
+  --cpg ~/Developer/dateutil-example/cpg.json \
+  --project-name dateutil-parser --language python --source-root dateutil \
+  --sanicode ~/Developer/dateutil-example/sanicode-result.json \
+  --veripak ~/Developer/dateutil-example/veripak-python-dateutil.json \
+  --cpg-rel-path cpg.json -o ~/Developer/dateutil-example/spec.json
+
+# Extract contracts (with resume support)
+python3 skills/extract-contracts/extract.py \
+  --spec ~/Developer/dateutil-example/spec.json \
+  --greploom-db ~/Developer/dateutil-example/greploom.db \
+  --cpg ~/Developer/dateutil-example/cpg.json \
+  --llm-endpoint https://gpt-oss-20b-gpt-oss-model.apps.cluster-n7pd5.n7pd5.sandbox5167.opentlc.com \
+  --scope "mod:parser" --skip-existing
+
+# Compare extracted contracts against gold standard
+python3 skills/extract-contracts/compare.py \
+  --extracted ~/Developer/dateutil-example/spec.json \
+  --reference spec-schema/examples/dateutil-parser.spec.json \
+  --id-map "mod:parser=mod:dateutil.parser"
+
+# Validate and render spec to Markdown
+python3 spec-schema/render.py \
+  --spec ~/Developer/dateutil-example/spec.json \
+  --schema spec-schema/spec.schema.json \
+  --template spec-schema/templates/spec-review.md.j2
+```
+
+## Rebuilding CPGs and indexes
+
+When treeloom or greploom versions change, or source code changes:
+
+```bash
+# Build CPG (scope to source root, include source text)
+cd ~/Developer/dateutil-example
+treeloom build --include-source --language python -o cpg.json src/
+
+# Rebuild greploom index (must specify --db explicitly)
+greploom index --force --db greploom.db cpg.json
+```
+
+After rebuilding CPGs, the skeleton spec must be regenerated (node IDs change with line numbers). Existing contracts are lost — back up `spec.json` first.
+
+## Key conventions
+
+- **Source text lives in `attrs.source_text`** in CPG nodes, not a top-level field. Greploom exposes it in the `text` field of query results when `--include-source` is passed.
+- **Element IDs** use the pattern `{prefix}:{qualified.name}` where prefix is `mod:`, `cls:`, or `fn:`. The qualified name is derived from the file path relative to the source root.
+- **`--scope` filtering** in extract.py uses prefix matching on element IDs. E.g. `--scope "mod:parser"` captures the parser module and all its children.
+- **Model choice**: gpt-oss-20B for quality, granite-8B as fallback for elements that timeout. vLLM endpoints drop ~15% of large prompts; `--skip-existing` handles this.
+
+## Known issues
+
+- vLLM connection drops on large prompts (~15% failure rate). Mitigated by `--skip-existing` resume. See issue #34.
+- Module-level contracts are weak (modules have minimal source in greploom).
+- LLM tends to use "fatal" severity where gold standard says "recoverable".
+- No test suite yet (issue #33).
+
+## Planning and history
+
+- `planning/code-translation-kit/roadmap.md` — Full roadmap (M0-M7), vertical plane model design
+- `retrospectives/` — Session retrospectives with recurring patterns and action items
+- `NEXT_SESSION.md` — Handoff notes for the next session (gitignored, local only)

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,83 +1,86 @@
-# Next Session: M2 continued — extract-intent + extraction improvements
+# Next Session: M2 continued — extract-intent
 
-## What happened this session (2026-04-17)
+## What happened this session (2026-04-17, session 2)
 
-Built the M2 extract-contracts skill. Three artifacts: `skills/extract-contracts/SKILL.md`, `extract.py`, and `compare.py`.
+### Infrastructure upgrades
+
+- **treeloom**: 0.7.0 → 0.9.0. CPGs now have `source_text` in `attrs` for all functions and classes.
+- **greploom**: 0.4.0 → 0.5.0. Rebuilt indexes for both dateutil and jsoup.
+- **dateutil CPG**: Rebuilt scoped to `src/`, 8,039 nodes, 355 with source text (all 306 functions + 49 classes).
+- **jsoup CPG**: Rebuilt scoped to `src/`, 63,055 nodes, source populated.
+- **dateutil spec**: Rebuilt skeleton with new node_refs — now 372 elements (full library, not just parser).
 
 ### Extraction results (dateutil parser module, gpt-oss-20B)
 
-- **78/91 elements** extracted successfully (85.7%)
-- **13 failures**: all connection drops from vLLM server on larger prompts (class-level nodes with extensive source code)
-- **77/91 parser elements** have populated contracts with `status: needs_review`
-- Enriched spec validates against schema with minor warnings only
+- **91/91 elements** extracted successfully (100%) across 4 runs with `--skip-existing`
+- **~15% connection drop rate** per run, but resume makes it manageable
+- All 4 LLM endpoints still responding on mcp-rhoai cluster
 
-### Key debugging story: greploom `text` field
+### Model comparison spot-check (isoparse, parserinfo, _parse)
 
-The first extraction run produced plausible-looking contracts but comparison against hand-crafted examples revealed the `parserinfo` class was completely hallucinated. Root cause: greploom returns source code in the `text` field, not `source`. The script was reading the wrong field, so the LLM had **zero source code** for all 91 elements and was guessing from function names + training data.
+| Dimension | gpt-oss-20B | granite-8B |
+|---|---|---|
+| Purpose quality | More precise, names specific components | More generic |
+| Postconditions | Much more detailed (4 items vs 2) | Sparse |
+| JSON reliability | Consistent | Failed once (invalid JSON on _parse) |
+| Trust boundary | Correct (out=trusted) | Sometimes wrong (out=untrusted) |
+| Error conditions | More granular (4 items vs 1 for isoparse) | Fewer, less specific |
 
-After fixing: parserinfo description went from wrong ("stores year, month, day...") to correct ("language-specific token mappings and parsing rules"). `_parse` invariants went from 0/2 to 2/2 covered.
+**Decision**: Use gpt-oss-20B as primary model. granite-8B only as fallback for elements that consistently timeout.
 
-### Comparison against 7 hand-crafted gold-standard contracts
+### Comparison against gold standard (7 hand-crafted contracts)
 
-| Metric | Run 1 (no source) | Run 3 (all fixes) |
-|--------|-------------------|--------------------|
-| Field coverage | 86% | **93%** |
-| Keyword overlap | 22% | **27%** |
-| `parse` error severity | `[recoverable]` only | **`[fatal, recoverable]` MATCH** |
-| `_parse` invariants | 0/2 | **2/2** |
-| parserinfo purpose | Hallucinated | **Correct** |
+| Metric | M2 session 1 (no source) | This session (source populated) |
+|---|---|---|
+| Field coverage | 93% | 86% |
+| Keyword overlap | 27% | 21% |
+| `_parse` invariants | 2/2 | 2/2 |
+| parserinfo purpose | Correct | Correct |
+| Extraction success rate | 85.7% | **100%** |
 
-### Known gaps (not fixable in M2 extraction)
+Coverage numbers dipped slightly but extraction is now complete. The quality difference may be due to changed element IDs affecting which elements map to gold standard, or the richer source context changing the LLM's output character.
 
-1. **CVE-2022-31688 not captured**: The CVE is not in veripak data or sanicode findings — it was human domain knowledge in the hand-crafted example. Flagged for M3 human review.
-2. **vLLM connection drops on large prompts**: ~15% failure rate on elements with large source code. The server drops connections after ~120s of generation. Retry with backoff helps but doesn't fully solve it.
-3. **Invariants often too generic**: LLM says "input is not modified" when the hand-crafted version says "token processing is single-pass, left to right." Improving this requires either few-shot examples in the prompt or a separate invariant-extraction pass.
-4. **Module-level contracts are weak**: Modules have minimal source code in greploom (just imports), so the LLM can't infer much about the module's role.
+### Code changes
 
-### Design decisions captured
-
-- **Element grouping**: Classes with ≤6 methods extracted together; larger classes split into individual calls (prevents vLLM timeouts)
-- **In-place spec update**: Contracts written directly to spec.json, not a separate file
-- **Security findings**: Suffix-matched by file path; ecosystem CVEs from veripak also injected into prompts
-- **Model name auto-resolution**: Script queries `/v1/models` to get the exact model ID (vLLM rejects "default")
+- **PR #36**: `--skip-existing` flag + incremental save for extract.py (on `chore/extract-contracts-resume` branch)
 
 ## What's next
 
-### Prerequisites (do these first)
+### Primary: extract-intent (M2 second skill)
 
-1. **Rebuild CPGs with treeloom 0.9.0+ and `--include-source`** (#35). The dateutil CPG was built with treeloom 0.7.0, which doesn't honor `--include-source` — all 8,039 nodes have zero source text. The installed treeloom is 0.7.0 despite M1 notes saying "rebuilt with 0.9.0." Upgrade treeloom, rebuild both dateutil and jsoup CPGs, rebuild greploom indexes. Then re-run extract-contracts to measure quality with source-populated CPGs.
+Build `skills/extract-intent/` — extracts business rules, domain logic, state lifecycle, and the "why" behind structures. Per the roadmap, this is the second M2 skill.
 
-2. **Verify LLM endpoints are still responding.** The mcp-rhoai cluster sandbox may have been recycled. Quick check: `curl -s <endpoint>/v1/models`.
+Key design questions to resolve:
+- How does intent differ from contracts? Contracts = observable behavior ("what"); intent = domain knowledge, design rationale ("why")
+- What does the output schema look like? Does it go in the spec alongside contracts, or in a separate section?
+- Does it need source code (greploom), or is it more about module-level patterns and relationships?
+- Should it run per-element like contracts, or per-module/per-class?
 
-### Remaining M2 work
+### Secondary: extraction quality improvements
 
-1. **extract-intent** — business rules, domain logic, state lifecycle, the "why" behind structures. Per the roadmap, this is the second M2 skill.
+1. Add few-shot examples to the system prompt (use hand-crafted contracts as exemplars)
+2. Two-pass approach: basic contract first, then refinement pass for invariants
+3. Handle module-level elements differently (aggregate info from child elements)
+4. Severity calibration: LLM uses "fatal" where gold says "recoverable"
 
-2. **Multi-model comparison** — Run extract-contracts on the same elements with granite-8B and ministral-14B. Compare quality across models. We have the infrastructure (`compare.py`) and endpoints ready.
+### Remaining M2 items
 
-3. **Extraction quality improvements**:
-   - Add few-shot examples to the system prompt (use hand-crafted contracts as exemplars)
-   - Consider a two-pass approach: extract basic contract first, then a refinement pass for invariants and trust boundaries
-   - Handle module-level elements differently (aggregate info from child elements)
+- Multi-model comparison (granite-8B, ministral-14B) — infrastructure ready, need to run and analyze
+- Merge PR #36
 
-4. **vLLM timeout mitigation** (#34):
-   - Try the gpt-oss-20b replica endpoint for load balancing
-   - Truncate greploom context to a token budget (e.g. 6000 tokens)
-   - Consider using the 8B model for large elements (faster generation)
-   - Check OpenShift route timeout annotations
-
-### Open issues from this session
+### Open issues
 
 | Issue | Repo | What |
 |-------|------|------|
 | #33 | code-translation-skills | Unit tests for extract.py and compare.py |
 | #34 | code-translation-skills | vLLM connection drops investigation |
-| #35 | code-translation-skills | Rebuild CPGs with treeloom 0.9.0+ |
+| #35 | code-translation-skills | Rebuild CPGs with treeloom 0.9.0+ (DONE) |
+| #36 | code-translation-skills | PR: --skip-existing for resumable extraction |
 | rdwj/greploom#30 | rdwj/greploom | Query JSON field naming improvement |
 
 ### Available LLM endpoints (mcp-rhoai cluster)
 
-Same as last session — all confirmed responding as of 2026-04-17.
+All confirmed responding as of 2026-04-17.
 
 | Model | Endpoint |
 |-------|----------|
@@ -86,12 +89,16 @@ Same as last session — all confirmed responding as of 2026-04-17.
 | RedHatAI/gpt-oss-20b replica (20B) | `https://gpt-oss-20b-2-gpt-oss-model-2.apps.cluster-n7pd5.n7pd5.sandbox5167.opentlc.com` |
 | mistralai/Ministral-3-14B-Instruct-2512 (14B) | `https://ministral-3-14b-instruct-mistral-model.apps.cluster-n7pd5.n7pd5.sandbox5167.opentlc.com` |
 
+### Tool versions
+
+- treeloom: 0.9.0
+- greploom: 0.5.0
+
 ### Reference files
 
 - `skills/extract-contracts/SKILL.md` — skill definition
-- `skills/extract-contracts/extract.py` — extraction script
+- `skills/extract-contracts/extract.py` — extraction script (with --skip-existing)
 - `skills/extract-contracts/compare.py` — comparison tool
 - `spec-schema/examples/dateutil-parser.spec.json` — hand-crafted gold standard
-- `dateutil-example/spec.json` — enriched spec from this session (77 contracts populated)
-- `dateutil-example/spec.json.skeleton` — backup of M1 skeleton
+- `dateutil-example/spec.json` — enriched spec (91/91 parser contracts, gpt-oss-20b)
 - `planning/code-translation-kit/roadmap.md` — M2 section

--- a/skills/extract-contracts/extract.py
+++ b/skills/extract-contracts/extract.py
@@ -85,6 +85,8 @@ def parse_args() -> argparse.Namespace:
                         help="Max methods per class group before splitting (default: 6).")
     parser.add_argument("--concurrency", type=int, default=4,
                         help="Max parallel LLM calls (default: 4; currently sequential).")
+    parser.add_argument("--skip-existing", action="store_true",
+                        help="Skip elements that already have a non-empty contract.")
     return parser.parse_args()
 
 
@@ -94,6 +96,12 @@ def parse_args() -> argparse.Namespace:
 def load_spec(path: str) -> dict:
     with open(path) as f:
         return json.load(f)
+
+
+def save_spec(path: str, spec: dict) -> None:
+    with open(path, "w") as f:
+        json.dump(spec, f, indent=2)
+        f.write("\n")
 
 
 # --Scope filtering
@@ -124,7 +132,14 @@ def filter_elements(elements: dict, scope: str) -> dict:
 # --Element grouping
 # --
 
-def group_elements(elements: dict, max_group_size: int = 6) -> list[dict]:
+def _has_contract(elem: dict) -> bool:
+    """Return True if the element already has a non-empty contract dict."""
+    contract = elem.get("contract")
+    return isinstance(contract, dict) and len(contract) > 0
+
+
+def group_elements(elements: dict, max_group_size: int = 6,
+                   skip_existing: bool = False) -> list[dict]:
     """Group class methods with their parent class.
 
     Each group is one of:
@@ -138,6 +153,9 @@ def group_elements(elements: dict, max_group_size: int = 6) -> list[dict]:
     Classes with more than max_group_size methods are split: the class itself
     becomes a single, and each method becomes a single. This keeps prompts
     small enough for remote LLM endpoints.
+
+    When skip_existing is True, singles with existing contracts are dropped,
+    and class groups where ALL members already have contracts are dropped.
     """
     class_members: dict[str, list[str]] = {}  # class_id -> [method_ids]
     class_ids: set[str] = set()
@@ -181,6 +199,18 @@ def group_elements(elements: dict, max_group_size: int = 6) -> list[dict]:
         if eid in class_ids or eid in grouped_methods:
             continue
         groups.append({"type": "single", "element_id": eid})
+
+    if skip_existing:
+        filtered = []
+        for g in groups:
+            if g["type"] == "single":
+                if _has_contract(elements[g["element_id"]]):
+                    continue
+            elif g["type"] == "class":
+                if all(_has_contract(elements[eid]) for eid in g["all_ids"]):
+                    continue
+            filtered.append(g)
+        groups = filtered
 
     return groups
 
@@ -604,11 +634,17 @@ def main() -> None:
         in_scope = elements
         print(f"Full scope: {len(in_scope)} elements")
 
-    groups = group_elements(in_scope, max_group_size=args.max_group_size)
+    all_groups = group_elements(in_scope, max_group_size=args.max_group_size,
+                                skip_existing=False)
+    groups = group_elements(in_scope, max_group_size=args.max_group_size,
+                            skip_existing=args.skip_existing)
+    n_skipped = len(all_groups) - len(groups)
     n_class = sum(1 for g in groups if g["type"] == "class")
     n_single = sum(1 for g in groups if g["type"] == "single")
     print(f"Grouped into {len(groups)} extraction units "
           f"({n_class} class groups, {n_single} singles)")
+    if n_skipped:
+        print(f"Skipped {n_skipped} groups with existing contracts")
 
     if args.dry_run:
         for g in groups:
@@ -638,15 +674,15 @@ def main() -> None:
                 print(f"ok ({s} extracted)")
             else:
                 print(f"partial ({s} ok, {f} failed)")
+            if s > 0:
+                save_spec(args.spec, spec)
         except Exception as exc:
             n = len(group.get("all_ids", [group.get("element_id")]))
             total_fail += n
             all_errors.append(f"{label}: {exc}")
             print(f"FAILED: {exc}")
 
-    with open(args.spec, "w") as fh:
-        json.dump(spec, fh, indent=2)
-        fh.write("\n")
+    save_spec(args.spec, spec)
 
     print(f"\nDone. {total_success} contracts extracted, {total_fail} failures.")
     if all_errors:


### PR DESCRIPTION
## Summary

- Add `--skip-existing` flag that skips elements with non-empty contracts, enabling resumable extraction after vLLM connection drops
- Save spec to disk after each successful group extraction (not just at the end), so progress persists even if the process dies
- Extract `save_spec()` helper and `_has_contract()` predicate

## Context

vLLM endpoints drop connections on ~15% of large prompts. Without resume, a full 91-element parser extraction required 4 runs to reach 100% coverage. With `--skip-existing`, each re-run picks up only the missing elements.

## Test plan

- [x] Verified with 4 sequential runs: 13 → 73 → 87 → 90 → 91/91 contracts
- [x] `--dry-run --skip-existing` correctly reports skipped group count
- [x] Incremental saves confirmed by checking spec.json mid-run